### PR TITLE
Throw custom die more than once.

### DIFF
--- a/dicebag/dicebag.lua
+++ b/dicebag/dicebag.lua
@@ -92,30 +92,37 @@ function M.roll_special_dice(num_sides, advantage, num_dice, num_results)
     return result
 end
 
----Roll a custom die. Parameter sides is a table in the format {{weight1, value1}, {weight2, value2} ...}. Returns the value of the rolled side.
-function M.roll_custom_dice(sides)
+---Roll one or more custom dice. Parameter sides is a table in the format {{weight1, value1}, {weight2, value2} ...}. Returns the total value of rolled custom dice.
+function M.roll_custom_dice(num_dice, sides)
 
-    local total_weight = 0
-    local num_sides = #sides
+    num_dice = num_dice or 1
 
-    --count up the total weight
-    for i=1,num_sides do
-        total_weight = total_weight + sides[i][1]
-    end
+    local result = 0
 
-    local weight_result = math.random() * total_weight
+    for i=1,num_dice do
+        local total_weight = 0
+        local num_sides = #sides
 
-    --find and return the resulting value
-    local processed_weight = 0
-    for i=1,num_sides do
-        if weight_result <= sides[i][1] + processed_weight then
-            return sides[i][2]
-        else
-            processed_weight = processed_weight + sides[i][1]
+        --count up the total weight
+        for i=1,num_sides do
+            total_weight = total_weight + sides[i][1]
+        end
+
+        local weight_result = math.random() * total_weight
+
+        --find and return the resulting value
+        local processed_weight = 0
+        for i=1,num_sides do
+            if weight_result <= sides[i][1] + processed_weight then
+                result = result + sides[i][2]
+                break
+            else
+                processed_weight = processed_weight + sides[i][1]
+            end
         end
     end
 
-    return 0
+    return result
 end
 
 ---Create a bag of green (success) and red (fail) "marbles" that you can draw from. If reset_on_success is true, the bag will be reset after the first green (success) marble is drawn, otherwise the bag will reset when all marbles have been drawn.

--- a/dicebag/dicebag.lua
+++ b/dicebag/dicebag.lua
@@ -98,20 +98,22 @@ function M.roll_custom_dice(num_dice, sides)
     num_dice = num_dice or 1
 
     local result = 0
+    local total_weight = 0
+    local num_sides = #sides
 
-    for i=1,num_dice do
-        local total_weight = 0
-        local num_sides = #sides
+    --count up the total weight
+    for i=1,num_sides do
+        total_weight = total_weight + sides[i][1]
+    end
 
-        --count up the total weight
-        for i=1,num_sides do
-            total_weight = total_weight + sides[i][1]
-        end
+    local weight_result = 0
+    local processed_weight = 0
 
-        local weight_result = math.random() * total_weight
+    for d=1,num_dice do
+        weight_result = math.random() * total_weight
 
         --find and return the resulting value
-        local processed_weight = 0
+        processed_weight = 0
         for i=1,num_sides do
             if weight_result <= sides[i][1] + processed_weight then
                 result = result + sides[i][2]


### PR DESCRIPTION
I was working on a c# version of this repo, and noticed that the current implementation forces the user to call M.roll_custom_dice() multiple times if they want to roll the same custom die more than once. I added a 'num_dice' variable to the function to allow throwing custom die more than once inside the function. Hope this PR works out! 